### PR TITLE
Improved getGeocodeFromGoogle method 

### DIFF
--- a/src/AnthonyMartin/GeoLocation/GeoLocation.php
+++ b/src/AnthonyMartin/GeoLocation/GeoLocation.php
@@ -224,7 +224,7 @@ class GeoLocation {
 	 *	@param string $key - the key provided by Google
 	 *	@return \stdClass
 	 */
-	public static function getGeocodeFromGoogle($location, $key) {
+	public static function getGeocodeFromGoogle($location, $key=null) {
 		$url = 'https://maps.googleapis.com/maps/api/geocode/json?address='.urlencode($location).'&sensor=false&key='.$key;
 		$ch = curl_init();
 	    curl_setopt($ch, CURLOPT_URL,$url);

--- a/src/AnthonyMartin/GeoLocation/GeoLocation.php
+++ b/src/AnthonyMartin/GeoLocation/GeoLocation.php
@@ -217,14 +217,15 @@ class GeoLocation {
 	}
 	/**
 	 *  Retrieves Geocoding information from Google
-	 *  eg. $response = GeoLocation::getGeocodeFromGoogle($location);
+	 *  eg. $response = GeoLocation::getGeocodeFromGoogle($location, $key);
 	 *		$latitude = $response->results[0]->geometry->location->lng;
 	 *	    $longitude = $response->results[0]->geometry->location->lng;
 	 *	@param string $location address, city, state, etc.
+	 *	@param string $key - the key provided by Google
 	 *	@return \stdClass
 	 */
-	public static function getGeocodeFromGoogle($location) {
-		$url = 'http://maps.googleapis.com/maps/api/geocode/json?address='.urlencode($location).'&sensor=false';
+	public static function getGeocodeFromGoogle($location, $key) {
+		$url = 'https://maps.googleapis.com/maps/api/geocode/json?address='.urlencode($location).'&sensor=false&key='.$key;
 		$ch = curl_init();
 	    curl_setopt($ch, CURLOPT_URL,$url);
 	    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
Since June 2018 Google requires a key to perform requests in the API. Solution: Added a new "key" argument in the method, passing the value to the url, so users of the Geolocation package will pass their keys by parameter. Also changed the protocol http to https, required by the Google.